### PR TITLE
Remove deprecation in Ember 2.1

### DIFF
--- a/addon/instance-initializers/browser-update.js
+++ b/addon/instance-initializers/browser-update.js
@@ -1,5 +1,5 @@
 export function initialize(appInstance) {
-  let service = appInstance.container.lookup('service:browser-update');
+  let service = appInstance.lookup('service:browser-update');
 
   service.inject();
 }


### PR DESCRIPTION
See: http://emberjs.com/deprecations/v2.x/#toc_ember-applicationinstance-container
Should also close #2.
